### PR TITLE
Fix document persistence and logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+OPENAI_API_KEY=your_key_here
+FRONTEND_URL=http://localhost:5173
+BACKEND_URL=http://localhost:8000
+VITE_FIREBASE_API_KEY=your_firebase_key
+VITE_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=your_project_id
+VITE_STRIPE_PUBLIC_KEY=pk_test_xxx
+VITE_BACKEND_URL=http://localhost:8000

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install backend deps
+        run: |
+          cd backend
+          pip install black
+          pip install -r requirements.txt
+      - name: Lint backend
+        run: |
+          black --check .
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install frontend deps
+        run: |
+          cd frontend
+          npm install
+      - name: Run frontend lint
+        run: |
+          cd frontend
+          npx eslint . --max-warnings=0
+      - name: Run tests
+        run: echo "No tests yet"
+      - name: Deploy Backend
+        if: github.ref == 'refs/heads/main'
+        uses: renderinc/render-build@v1
+        with:
+          service-id: ${{ secrets.RENDER_SERVICE_ID }}
+          api-key: ${{ secrets.RENDER_API_KEY }}
+      - name: Deploy Frontend
+        if: github.ref == 'refs/heads/main'
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Base image for backend and frontend
+FROM python:3.12-slim as backend
+WORKDIR /app
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend ./backend
+
+FROM node:22-alpine as frontend
+WORKDIR /ui
+COPY frontend/package.json ./
+RUN npm install
+COPY frontend ./
+RUN npm run build
+
+FROM python:3.12-slim
+WORKDIR /app
+COPY --from=backend /app/backend ./backend
+COPY --from=backend /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=frontend /ui/dist ./frontend/dist
+COPY backend/main.py ./main.py
+ENV PORT=8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,93 @@
 # LegalLens
+
+LegalLens is a demo application that explains legal PDFs using OpenAI. It features a FastAPI backend and a React + Vite frontend.
+
+## Setup
+
+Install dependencies using the setup script (requires internet access):
+
+```bash
+./run/setup.sh
+```
+
+Copy `.env.example` to `.env` and supply your OpenAI key.
+
+## Development
+
+### Backend
+
+```bash
+cd backend
+uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm run dev
+```
+
+Visit `http://localhost:5173` to view the app.
+
+## API
+
+### `POST /upload`
+
+Upload a PDF with `multipart/form-data`. The response contains extracted
+clauses as a list of dictionaries with `id` and `text` fields:
+
+```json
+{
+  "clauses": [
+    {"id": 1, "text": "Clause text..."}
+  ]
+}
+```
+
+### `POST /explain`
+
+Send a JSON payload with a list of clauses to receive plain-English
+explanations. Example request body:
+
+```json
+{
+  "clauses": [
+    {"id": 1, "text": "Clause text..."}
+  ]
+}
+```
+
+The response mirrors the input IDs and includes an `explanation` field:
+
+```json
+{
+  "clauses": [
+    {"id": 1, "original": "Clause text...", "explanation": "..."}
+  ]
+}
+```
+
+## Environment Variables
+See `.env.example` for all configuration options including Firebase auth and Stripe.
+
+## Docker
+You can run the entire stack with Docker:
+
+```bash
+docker-compose up --build
+```
+
+The frontend will be available on `http://localhost:5173` and the backend on `http://localhost:8000`.
+
+### CI/CD
+GitHub Actions pipeline (`.github/workflows/deploy.yml`) installs dependencies, runs lint checks and deploys to Render/Vercel using repository secrets.
+
+### Logging
+Server events such as uploads, explanations, reanalysis and exports are logged daily in JSON format under `logs/`.
+
+## Exporting Data
+Use the **Export JSON** button while viewing clauses to download a JSON file containing the text, explanations, tags, summaries, severity, and tone for each clause. An API placeholder exists at `GET /export/{session_id}`.
+
+## Billing
+`/billing` endpoints provide mocked Stripe checkout and usage routes. Integrate your Stripe keys when moving to production.

--- a/backend/gpt_client.py
+++ b/backend/gpt_client.py
@@ -1,0 +1,92 @@
+import os
+import json
+from dotenv import load_dotenv
+import openai
+
+load_dotenv()
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+openai.api_key = OPENAI_API_KEY
+
+SYSTEM_PROMPT = (
+    "You are a legal assistant providing plain-English explanations of contract clauses."
+)
+
+async def explain_text(text: str) -> str:
+    """Call OpenAI asynchronously to get an explanation for the provided text."""
+    if not OPENAI_API_KEY:
+        return f"(demo) Explanation for: {text[:60]}"
+
+    response = await openai.ChatCompletion.acreate(
+        model="gpt-4o",
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": text},
+        ],
+    )
+    return response.choices[0].message.content.strip()
+
+
+def explain_clause(clause_text: str) -> str:
+    """Return a plain-English explanation for a single clause."""
+    if not OPENAI_API_KEY:
+        return "Explanation unavailable (no API key configured)."
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": f"Explain the following legal clause in plain English: {clause_text}"},
+        ],
+    )
+    return response.choices[0].message.content.strip()
+
+
+def analyze_clause(clause_text: str) -> dict:
+    """Return explanation with brief summary, tags and severity."""
+    if not OPENAI_API_KEY:
+        return {
+            "explanation": "Explanation unavailable (no API key configured).",
+            "briefSummary": clause_text[:60],
+            "tags": [],
+            "severity": 1,
+        }
+
+    prompt = (
+        "Explain the following legal clause in plain English. "
+        "Provide a JSON object with fields 'explanation', 'briefSummary', "
+        "'tags', and 'severity' (1-5). Clause: " + clause_text
+    )
+
+    response = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+    )
+
+    content = response.choices[0].message.content.strip()
+    try:
+        return json.loads(content)
+    except Exception:
+        return {
+            "explanation": content,
+            "briefSummary": "",
+            "tags": [],
+            "severity": 1,
+        }
+
+
+async def reanalyze_clause(clause_text: str, tone: str) -> str:
+    """Return an explanation with the requested tone."""
+    if not OPENAI_API_KEY:
+        return f"(demo {tone}) {clause_text[:60]}"
+
+    style = {
+        "Plain": "Explain simply:",
+        "Friendly": "Explain like you're a helpful friend:",
+        "Formal": "Explain in professional legal terms:",
+    }.get(tone, "Explain simply:")
+
+    return await explain_text(f"{style} {clause_text}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,27 @@
+import os
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+
+from .routes import upload, document, reanalyze, explain, export, billing
+
+load_dotenv()
+
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:5173")
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[FRONTEND_URL],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(upload.router)
+app.include_router(document.router)
+app.include_router(reanalyze.router)
+app.include_router(explain.router)
+app.include_router(export.router)
+app.include_router(billing.router)

--- a/backend/parser.py
+++ b/backend/parser.py
@@ -1,0 +1,47 @@
+"""Utilities for extracting clauses from a PDF."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+import pdfplumber
+
+
+def _split_long_text(text: str, max_len: int = 300) -> List[str]:
+    """Split a long paragraph into chunks no longer than max_len."""
+    sentences = re.split(r"(?<=\.)\s+", text)
+    chunks: List[str] = []
+    current = ""
+    for sentence in sentences:
+        if len(current) + len(sentence) > max_len and current:
+            chunks.append(current.strip())
+            current = sentence
+        else:
+            current += (" " if current else "") + sentence
+    if current.strip():
+        chunks.append(current.strip())
+    return chunks
+
+
+def extract_clauses(file_path: str) -> List[Dict[str, str]]:
+    """Open a PDF and return a list of clause dictionaries with ids."""
+
+    with pdfplumber.open(file_path) as pdf:
+        text = "\n".join(page.extract_text() or "" for page in pdf.pages)
+
+    raw_parts = re.split(r"\n{2,}", text)
+    clauses: List[Dict[str, str]] = []
+    cid = 1
+    for part in raw_parts:
+        cleaned = part.strip()
+        if not cleaned:
+            continue
+
+        pieces = [cleaned] if len(cleaned) <= 300 else _split_long_text(cleaned)
+
+        for piece in pieces:
+            clauses.append({"id": cid, "text": piece})
+            cid += 1
+
+    return clauses

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,9 @@
+nginx
+fastapi
+uvicorn
+openai
+python-dotenv
+pdfplumber
+aiofiles
+python-multipart
+stripe

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -1,0 +1,3 @@
+from . import upload, document, reanalyze, explain, export, billing
+
+__all__ = ["upload", "document", "reanalyze", "explain", "export", "billing"]

--- a/backend/routes/billing.py
+++ b/backend/routes/billing.py
@@ -1,0 +1,20 @@
+"""Stripe billing endpoints scaffold."""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.post('/billing/create-checkout-session')
+async def create_checkout():
+    """Start a Stripe checkout session (placeholder)."""
+    return {"url": "https://stripe.com/checkout-session"}
+
+@router.post('/billing/webhook')
+async def webhook():
+    """Handle Stripe webhook events."""
+    return {"status": "ok"}
+
+@router.get('/billing/usage/{user_id}')
+async def usage(user_id: str):
+    """Return usage data for user."""
+    return {"user": user_id, "docs": 0}

--- a/backend/routes/document.py
+++ b/backend/routes/document.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter, HTTPException
+from ..state import documents
+
+router = APIRouter()
+
+@router.get("/document/{doc_id}")
+async def get_document(doc_id: str):
+    if doc_id not in documents:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return {"clauses": documents[doc_id]}

--- a/backend/routes/explain.py
+++ b/backend/routes/explain.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Request
+from typing import List, Dict
+
+from ..gpt_client import analyze_clause
+from ..utils.logging import logger
+
+router = APIRouter()
+
+@router.post("/explain")
+async def explain(request: Request, clauses: Dict[str, List[Dict]]):
+    """Return detailed explanations for provided clauses."""
+    data = []
+    for item in clauses.get("clauses", []):
+        cid = item.get("id")
+        text = item.get("text", "")
+        details = analyze_clause(text)
+        details.update({"id": cid, "original": text})
+        data.append(details)
+    logger.info(
+        "explain",
+        extra={
+            "event": "explain",
+            "ip": request.client.host if request.client else None,
+            "count": len(data),
+        },
+    )
+    return {"clauses": data}

--- a/backend/routes/export.py
+++ b/backend/routes/export.py
@@ -1,0 +1,21 @@
+"""Placeholder export route."""
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from ..utils.logging import logger
+
+router = APIRouter()
+
+@router.get("/export/{session_id}")
+async def export(request: Request, session_id: str):
+    """Return all clauses for a document session."""
+    # Placeholder: would look up session and return full data
+    logger.info(
+        "export",
+        extra={
+            "event": "export",
+            "ip": request.client.host if request.client else None,
+            "session": session_id,
+        },
+    )
+    return JSONResponse({"session_id": session_id, "clauses": []})

--- a/backend/routes/reanalyze.py
+++ b/backend/routes/reanalyze.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Request
+from ..gpt_client import reanalyze_clause
+from ..utils.schema import ReanalyzeRequest
+from ..utils.logging import logger
+
+router = APIRouter()
+
+@router.post("/reanalyze")
+async def reanalyze(request: Request, req: ReanalyzeRequest):
+    explanation = await reanalyze_clause(req.text, req.tone)
+    logger.info(
+        "reanalyze",
+        extra={
+            "event": "reanalyze",
+            "ip": request.client.host if request.client else None,
+            "tone": req.tone,
+        },
+    )
+    return {"id": req.id, "text": req.text, "explanation": explanation}

--- a/backend/routes/upload.py
+++ b/backend/routes/upload.py
@@ -1,0 +1,34 @@
+"""Upload route for parsing PDF files."""
+
+import uuid
+from fastapi import APIRouter, File, HTTPException, UploadFile, Request
+
+from ..parser import extract_clauses
+from ..utils.logging import logger
+from ..state import documents
+
+router = APIRouter()
+
+
+@router.post("/upload")
+async def upload(request: Request, file: UploadFile = File(...)):
+    if file.content_type != "application/pdf":
+        raise HTTPException(status_code=400, detail="Invalid file type")
+
+    tmp_path = f"/tmp/{uuid.uuid4()}.pdf"
+    with open(tmp_path, "wb") as buffer:
+        buffer.write(await file.read())
+
+    clauses = extract_clauses(tmp_path)
+    doc_id = str(uuid.uuid4())
+    documents[doc_id] = clauses
+    logger.info(
+        "upload",
+        extra={
+            "event": "upload",
+            "ip": request.client.host if request.client else None,
+            "count": len(clauses),
+            "document_id": doc_id,
+        },
+    )
+    return {"document_id": doc_id, "clauses": clauses}

--- a/backend/state.py
+++ b/backend/state.py
@@ -1,0 +1,7 @@
+from typing import Dict, List
+from .utils.schema import Clause
+
+# Simple in-memory store for uploaded documents
+# Keyed by generated document ID
+
+documents: Dict[str, List[Clause]] = {}

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["logging", "schema"]

--- a/backend/utils/logging.py
+++ b/backend/utils/logging.py
@@ -1,0 +1,29 @@
+import logging
+from logging.handlers import TimedRotatingFileHandler
+import json
+from pathlib import Path
+
+LOG_DIR = Path("logs")
+LOG_DIR.mkdir(exist_ok=True)
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record):
+        data = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        standard = logging.LogRecord(None, None, "", 0, "", [], None).__dict__.keys()
+        extras = {k: v for k, v in record.__dict__.items() if k not in standard}
+        if record.args:
+            data.update(record.args)
+        data.update(extras)
+        return json.dumps(data)
+
+handler = TimedRotatingFileHandler(LOG_DIR / "legallens.log", when="D")
+handler.setFormatter(JsonFormatter())
+
+logger = logging.getLogger("legallens")
+logger.setLevel(logging.INFO)
+logger.addHandler(handler)
+logger.propagate = False

--- a/backend/utils/schema.py
+++ b/backend/utils/schema.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+class Clause(BaseModel):
+    text: str
+    explanation: str
+    tags: List[str] = []
+    severity: int = 1
+
+class DocumentResponse(BaseModel):
+    clauses: List[Clause]
+
+class ReanalyzeRequest(BaseModel):
+    id: int
+    text: str
+    tone: str = "Plain"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  backend:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    volumes:
+      - .:/app
+  frontend:
+    image: node:22-alpine
+    working_dir: /ui
+    volumes:
+      - ./frontend:/ui
+    command: sh -c "npm install && npm run dev"
+    ports:
+      - "5173:5173"
+    environment:
+      - VITE_BACKEND_URL=http://localhost:8000
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: legallens
+      POSTGRES_PASSWORD: legallens
+      POSTGRES_DB: legallens
+    ports:
+      - "5432:5432"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LegalLens</title>
+  </head>
+  <body class="min-h-screen bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "legallens-ui",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tailwindcss": "^3.4.1",
+    "@shadcn/ui": "latest",
+    "axios": "^1.5.0",
+    "react-router-dom": "^6.23.0",
+    "firebase": "^10.7.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import UploadPage from './pages/Upload'
+import ClauseViewer from './components/ClauseViewer'
+import Login from './pages/Login'
+import Pricing from './pages/Pricing'
+import Header from './components/Header'
+import RequireAuth from './components/RequireAuth'
+import { Clause } from './lib/api'
+
+export default function App() {
+  const [clauses, setClauses] = useState<Clause[]>([])
+
+  return (
+    <BrowserRouter>
+      <Header />
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/pricing" element={<Pricing />} />
+        <Route
+          path="/"
+          element={
+            <RequireAuth>
+              <UploadPage onComplete={setClauses} />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/view"
+          element={
+            <RequireAuth>
+              <ClauseViewer clauses={clauses} />
+            </RequireAuth>
+          }
+        />
+      </Routes>
+    </BrowserRouter>
+  )
+}

--- a/frontend/src/components/ClauseCard.tsx
+++ b/frontend/src/components/ClauseCard.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+export interface Clause {
+  text: string
+  explanation: string
+  tags?: string[]
+  severity?: number
+}
+
+export default function ClauseCard({ clause }: { clause: Clause }) {
+  return (
+    <div className="border p-2 rounded bg-white">
+      <p className="font-medium">{clause.text}</p>
+      <p className="text-sm text-gray-600 mt-1">{clause.explanation}</p>
+    </div>
+  )
+}

--- a/frontend/src/components/ClauseViewer.tsx
+++ b/frontend/src/components/ClauseViewer.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react'
+import { Clause, explainClause, reanalyzeClause, Explanation } from '../lib/api'
+import TLDRSidebar, { ClauseSummary } from './TLDRSidebar'
+import ExportButton from './ExportButton'
+import Loader from './Loader'
+
+export default function ClauseViewer({ clauses }: { clauses: Clause[] }) {
+  const [explanations, setExplanations] = useState<Record<number, string>>({})
+  const [summaries, setSummaries] = useState<Record<number, ClauseSummary>>({})
+  const [tones, setTones] = useState<Record<number, string>>({})
+  const [showSidebar, setShowSidebar] = useState(() => {
+    if (typeof window !== 'undefined' && window.innerWidth < 768) return false
+    return true
+  })
+
+  const handleExplain = async (cl: Clause) => {
+    setExplanations(prev => ({ ...prev, [cl.id]: '__loading__' }))
+    const resp = await explainClause(cl.text)
+    setExplanations(prev => ({ ...prev, [cl.id]: resp.explanation }))
+    setSummaries(prev => ({
+      ...prev,
+      [cl.id]: {
+        id: cl.id,
+        briefSummary: resp.briefSummary || '',
+        tags: resp.tags || [],
+        severity: resp.severity || 1,
+      },
+    }))
+  }
+
+  const handleToneChange = async (cl: Clause, tone: string) => {
+    setTones(prev => ({ ...prev, [cl.id]: tone }))
+    setExplanations(prev => ({ ...prev, [cl.id]: '__loading__' }))
+    const resp = await reanalyzeClause(cl.id, cl.text, tone)
+    setExplanations(prev => ({ ...prev, [cl.id]: resp.explanation }))
+  }
+
+  return (
+    <div className="flex">
+      <div className="flex-1 space-y-4 overflow-y-auto max-h-[70vh] p-2">
+        <button
+          className="md:hidden mb-2 text-sm text-blue-500 focus:outline-blue-700"
+          onClick={() => setShowSidebar(!showSidebar)}
+          aria-label="Toggle summaries sidebar"
+        >
+          {showSidebar ? 'Hide Summary' : 'Show Summary'}
+        </button>
+        {clauses.map(cl => (
+          <div key={cl.id} className="border p-2 rounded bg-white">
+            <p>{cl.text}</p>
+            <div className="mt-2 flex items-center space-x-2">
+              <button
+                className="px-2 py-1 bg-blue-500 text-white rounded focus:outline-blue-700"
+                onClick={() => handleExplain(cl)}
+                aria-label={`Explain clause ${cl.id}`}
+              >
+                Explain
+              </button>
+              <select
+                className="border p-1 rounded focus:outline-blue-700"
+                value={tones[cl.id] || 'Plain'}
+                onChange={e => handleToneChange(cl, e.target.value)}
+                aria-label={`Tone for clause ${cl.id}`}
+              >
+                <option value="Plain">Plain</option>
+                <option value="Friendly">Friendly</option>
+                <option value="Formal">Formal</option>
+              </select>
+            </div>
+            {explanations[cl.id] === '__loading__' ? (
+              <Loader />
+            ) : (
+              explanations[cl.id] && (
+                <p className="mt-1 text-sm text-gray-600">{explanations[cl.id]}</p>
+              )
+            )}
+          </div>
+        ))}
+        <ExportButton
+          clauses={clauses}
+          explanations={explanations}
+          summaries={summaries}
+          tones={tones}
+        />
+      </div>
+      {showSidebar && <TLDRSidebar summaries={Object.values(summaries)} />}
+    </div>
+  )
+}

--- a/frontend/src/components/ExportButton.tsx
+++ b/frontend/src/components/ExportButton.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { Clause } from '../lib/api'
+import { ClauseSummary } from './TLDRSidebar'
+import Loader from './Loader'
+
+interface Props {
+  clauses: Clause[]
+  explanations: Record<number, string>
+  summaries: Record<number, ClauseSummary>
+  tones: Record<number, string>
+}
+
+export default function ExportButton({ clauses, explanations, summaries, tones }: Props) {
+  const [loading, setLoading] = React.useState(false)
+  const handleExport = () => {
+    setLoading(true)
+    const data = clauses.map(cl => ({
+      text: cl.text,
+      explanation: explanations[cl.id] || '',
+      summary: summaries[cl.id]?.briefSummary || '',
+      tags: summaries[cl.id]?.tags || [],
+      severity: summaries[cl.id]?.severity || 1,
+      tone: tones[cl.id] || 'Plain',
+    }))
+    const blob = new Blob([JSON.stringify({ clauses: data }, null, 2)], {
+      type: 'application/json',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'legallens_export.json'
+    a.click()
+    URL.revokeObjectURL(url)
+    setLoading(false)
+  }
+
+  return (
+    <button
+      onClick={handleExport}
+      className="px-3 py-1 bg-green-500 text-white rounded mt-4 focus:outline-blue-700"
+      aria-label="Export annotations as JSON"
+    >
+      {loading ? <Loader /> : 'Export JSON'}
+    </button>
+  )
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { signOut } from 'firebase/auth'
+import { auth } from '../firebase'
+import { Link } from 'react-router-dom'
+
+export default function Header() {
+  const handleLogout = async () => {
+    await signOut(auth)
+  }
+
+  return (
+    <div className="flex items-center justify-between p-4 border-b mb-4">
+      <Link to="/" className="font-bold text-xl">LegalLens</Link>
+      <div className="space-x-4">
+        <Link to="/pricing">Pricing</Link>
+        <button onClick={handleLogout} className="text-sm text-red-500">Logout</button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Loader.tsx
+++ b/frontend/src/components/Loader.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function Loader() {
+  return (
+    <div className="flex items-center space-x-2" role="status" aria-label="Loading">
+      <div className="w-4 h-4 border-2 border-gray-300 border-t-blue-500 rounded-full animate-spin" />
+      <span>Processing...</span>
+    </div>
+  )
+}

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react'
+import { onAuthStateChanged } from 'firebase/auth'
+import { auth } from '../firebase'
+import { Navigate } from 'react-router-dom'
+
+export default function RequireAuth({ children }: { children: JSX.Element }) {
+  const [loading, setLoading] = useState(true)
+  const [user, setUser] = useState<any>(null)
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, u => {
+      setUser(u)
+      setLoading(false)
+    })
+    return () => unsub()
+  }, [])
+
+  if (loading) return null
+  if (!user) return <Navigate to="/login" replace />
+  return children
+}

--- a/frontend/src/components/TLDRSidebar.tsx
+++ b/frontend/src/components/TLDRSidebar.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react'
+
+export interface ClauseSummary {
+  id: number
+  briefSummary: string
+  tags: string[]
+  severity: number
+}
+
+export default function TLDRSidebar({ summaries }: { summaries: ClauseSummary[] }) {
+  const [expanded, setExpanded] = useState(() => {
+    if (typeof window !== 'undefined' && window.innerWidth < 768) {
+      return new Set<number>()
+    }
+    return new Set(summaries.map(s => s.id))
+  })
+  const allExpanded = summaries.every(s => expanded.has(s.id))
+
+  const toggleAll = () => {
+    if (allExpanded) {
+      setExpanded(new Set())
+    } else {
+      setExpanded(new Set(summaries.map(s => s.id)))
+    }
+  }
+
+  const toggle = (id: number) => {
+    setExpanded(prev => {
+      const n = new Set(prev)
+      if (n.has(id)) n.delete(id)
+      else n.add(id)
+      return n
+    })
+  }
+
+  return (
+    <div id="sidebar" className="w-64 border-l bg-gray-50 p-4 overflow-y-auto">
+      <button
+        onClick={toggleAll}
+        className="text-sm text-blue-500 mb-4 focus:outline-blue-700"
+        aria-label={allExpanded ? 'Collapse all summaries' : 'Expand all summaries'}
+      >
+        {allExpanded ? 'Collapse All' : 'Expand All'}
+      </button>
+      {summaries.map(s => (
+        <div key={s.id} className="mb-2">
+          <button
+            className="cursor-pointer font-medium focus:outline-blue-700"
+            onClick={() => toggle(s.id)}
+            aria-expanded={expanded.has(s.id)}
+            aria-controls={`summary-${s.id}`}
+          >
+            Clause {s.id}
+          </button>
+          {expanded.has(s.id) && (
+            <div className="ml-2 text-sm" id={`summary-${s.id}`}>
+              <p>{s.briefSummary}</p>
+              <p className="text-xs">Tags: {s.tags.join(', ')}</p>
+              <p className="text-xs">Severity: {s.severity}</p>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/firebase.ts
+++ b/frontend/src/firebase.ts
@@ -1,0 +1,11 @@
+import { initializeApp } from 'firebase/app'
+import { getAuth } from 'firebase/auth'
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+}
+
+const app = initializeApp(firebaseConfig)
+export const auth = getAuth(app)

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,1 @@
+@import './styles/global.css';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,44 @@
+import axios from 'axios'
+
+export interface Clause {
+  id: number
+  text: string
+}
+
+export interface Explanation {
+  id: number
+  original: string
+  explanation: string
+  briefSummary?: string
+  tags?: string[]
+  severity?: number
+}
+
+const BASE_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000'
+
+export async function uploadPDF(file: File): Promise<Clause[]> {
+  const form = new FormData()
+  form.append('file', file)
+  const { data } = await axios.post(`${BASE_URL}/upload`, form)
+  return data.clauses as Clause[]
+}
+
+export async function explainClause(text: string): Promise<Explanation> {
+  const { data } = await axios.post(`${BASE_URL}/explain`, {
+    clauses: [{ id: 1, text }],
+  })
+  return data.clauses[0] as Explanation
+}
+
+export async function reanalyzeClause(
+  id: number,
+  text: string,
+  tone: string
+): Promise<Explanation> {
+  const { data } = await axios.post(`${BASE_URL}/reanalyze`, {
+    id,
+    text,
+    tone,
+  })
+  return data as Explanation
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react'
+import { signInWithEmailAndPassword } from 'firebase/auth'
+import { auth } from '../firebase'
+import { useNavigate } from 'react-router-dom'
+
+export default function Login() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const navigate = useNavigate()
+
+  const handleLogin = async () => {
+    try {
+      await signInWithEmailAndPassword(auth, email, password)
+      navigate('/')
+    } catch (e) {
+      setError('Failed to login')
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-bold">Login</h2>
+      {error && <p className="text-red-500">{error}</p>}
+      <input
+        type="email"
+        className="border p-2 block"
+        placeholder="Email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        className="border p-2 block"
+        placeholder="Password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <button onClick={handleLogin} className="px-3 py-1 bg-blue-500 text-white rounded">
+        Login
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/Pricing.tsx
+++ b/frontend/src/pages/Pricing.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export default function Pricing() {
+  return (
+    <div className="p-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="border p-4 rounded text-center">
+        <h3 className="font-bold">Free</h3>
+        <p className="text-2xl">$0</p>
+        <p>3 docs/mo</p>
+      </div>
+      <div className="border p-4 rounded text-center">
+        <h3 className="font-bold">Pro</h3>
+        <p className="text-2xl">$29/mo</p>
+        <p>Unlimited docs</p>
+      </div>
+      <div className="border p-4 rounded text-center">
+        <h3 className="font-bold">Enterprise</h3>
+        <p className="text-2xl">$99/mo</p>
+        <p>Priority support</p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react'
+import { uploadPDF, Clause } from '../lib/api'
+import Loader from '../components/Loader'
+import { useNavigate } from 'react-router-dom'
+
+interface Props {
+  onComplete: (clauses: Clause[]) => void
+}
+
+export default function Upload({ onComplete }: Props) {
+  const [file, setFile] = useState<File | null>(null)
+  const [loading, setLoading] = useState(false)
+  const navigate = useNavigate()
+
+  const handleUpload = async () => {
+    if (!file) return
+    setLoading(true)
+    const clauses = await uploadPDF(file)
+    onComplete(clauses)
+    setLoading(false)
+    navigate('/view')
+  }
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+      setFile(e.dataTransfer.files[0])
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div
+        onDragOver={e => e.preventDefault()}
+        onDrop={onDrop}
+        className="border-dashed border-2 border-gray-400 p-6 text-center"
+      >
+        Drag PDF here or
+        <input
+          type="file"
+          accept="application/pdf"
+          onChange={e => setFile(e.target.files ? e.target.files[0] : null)}
+          className="block mx-auto mt-2"
+        />
+      </div>
+      <button
+        onClick={handleUpload}
+        className="px-4 py-1 bg-blue-500 text-white rounded focus:outline-blue-700"
+        disabled={loading}
+        aria-label="Upload PDF"
+      >
+        {loading ? <Loader /> : 'Upload'}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Responsive layout adjustments */
+body {
+  @apply min-h-screen bg-gray-100;
+}
+
+#sidebar {
+  @apply w-64 md:block hidden;
+}
+
+@media (max-width: 767px) {
+  #sidebar {
+    @apply hidden;
+  }
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}',
+    './src/styles/**/*.css'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd backend
+pip install -r requirements.txt
+cd ../frontend
+npm install
+cd ..


### PR DESCRIPTION
## Summary
- store parsed clauses in new `backend/state.py`
- return document ID in `/upload` and fetch via `/document/{id}`
- capture extra log fields in `JsonFormatter`
- add `VITE_BACKEND_URL` to example env file
- fail CI on frontend lint

## Testing
- `./run/setup.sh` *(fails: 403 Forbidden during dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_6845c3e956e8832d8560581ea4d818b9